### PR TITLE
Initial implementation of select-cards.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ rand= "0.8.4"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json= "1.0.67"
 toml= "0.5.8"
-itertools= "0.10"
+itertools= "0.10.1"
 colored= "2"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# CribbageRust
+
+This project implements a set of REST APIs that allow you to build a cribbage application.  Cards are spelled as NameOfSuit (e.g. AceOfSpades or KingOfClubs).
+
+This is a Rust port of [https://github.com/joelong01/CribbageJS](https://github.com/joelong01/CribbageJS)
+
+## Prerequisites
+
+- [Rust](https://www.rust-lang.org/tools/install)
+
+*vscode is the recommended IDE*
+- [vscode](https://code.visualstudio.com/Download)
+- [Dev Containers Extension](https://github.com/microsoft/vscode-dev-containers)
+- [CodeLLDB Extension](https://github.com/vadimcn/vscode-lldb)
+
+## Build
+
+Build the project and run all unit and integration tests.
+`
+    $cargo build
+`
+
+## Test
+
+Compile, build and run all unit and integration tests.
+`
+    $cargo test
+`
+
+## Run
+
+Compule, build and run the executable.
+`
+    $cargo run
+`

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,2 +1,3 @@
 pub mod cards;
 pub mod scoring;
+pub mod select_cards;

--- a/src/game/scoring.rs
+++ b/src/game/scoring.rs
@@ -3,11 +3,14 @@ use arrayvec::IntoIter;
 use itertools::*;
 use std::convert::TryInto;
 
-pub fn score_hand(hand: &[Card], shared_card: &Card, is_crib: bool) -> i32 {
+pub fn score_hand(hand: &[Card], shared_card: Option<&Card>, is_crib: bool) -> i32 {
     let mut local_score = score_nibs(hand, shared_card);
 
     let mut local_hand: Vec<Card> = hand.to_vec();
-    local_hand.push(shared_card.clone());
+
+    if shared_card.is_some() {
+        local_hand.push(shared_card.unwrap().clone());
+    }
 
     local_score += score_flush(&local_hand, is_crib);
 
@@ -33,12 +36,14 @@ fn score_same_kind(hand: &[Card]) -> i32 {
     local_score
 }
 
-fn score_nibs(hand: &[Card], shared_card: &Card) -> i32 {
-    if hand
-        .iter()
-        .any(|card| card.suit() == shared_card.suit() && card.ordinal() == Ordinal::Jack)
-    {
-        return 1;
+fn score_nibs(hand: &[Card], shared_card: Option<&Card>) -> i32 {
+    if shared_card.is_some() {
+        if hand
+            .iter()
+            .any(|card| card.suit() == shared_card.unwrap().suit() && card.ordinal() == Ordinal::Jack)
+        {
+            return 1;
+        }
     }
 
     0

--- a/src/game/select_cards.rs
+++ b/src/game/select_cards.rs
@@ -1,0 +1,143 @@
+use crate::game::cards::*;
+use crate::game::scoring::*;
+use itertools::Itertools;
+
+/**
+ * go through each of the 16 combinations looking for the hand
+ * that will perform best based on the value of the hand plus
+ * or minus the value of the crib
+ */
+pub fn select_crib_cards(hand: &[Card], is_my_crib: bool) -> Vec<Card>{
+
+    // get all possible hands
+    let local_hand = hand.to_vec();
+    let potential_hands = local_hand.into_iter().combinations(4);
+    let mut max_crib = Vec::<Card>::new();
+    let mut max_score = -1000;
+    
+    for h in potential_hands {
+
+        // get the score for the current hand we are evaluating
+        let mut score = score_hand(hand, None, false);
+        let crib = get_crib_cards(hand, &h);
+
+        if is_my_crib {
+            // TODO: implement CardScoring.getCardValueToYourCrib
+            score = 1;
+        }
+        else {
+            // TODO: implement CardScoring.getCardValueToYourCrib
+            score = -2000;
+        }
+
+        if score > max_score {
+            max_score = score;
+            max_crib = crib.clone();
+        }
+    }
+
+    return max_crib;
+}
+
+/**
+ * hand has 6 cards and is passed in by the client
+ * heldCards has 4 cards and is generated via permutation
+ * this returns the 2 cards that are in the hand but not the crib
+*/
+fn get_crib_cards(hand: &[Card], held_cards: &[Card]) -> Vec<Card> {
+    let local_hand: Vec<Card> = hand.to_vec();
+    let mut send_to_crib = Vec::<Card>::new();
+
+    for h in local_hand.iter() {
+        if !held_cards.contains(&h) {
+            send_to_crib.push(h.clone());
+        }
+    }
+
+    return send_to_crib;
+}
+
+mod tests {
+    // import names from outer scope
+    use super::*;
+
+    #[test]
+    fn test_select_crib_cards_hand_returns_zero() {
+
+        // prepare test parameters
+        let test_hand = "FiveOfHearts,FiveOfClubs,SixOfHearts,SixOfClubs";
+        let mut hand: Vec<Card> = Vec::new();
+
+        for card_name in test_hand.split(',') {
+            hand.push(Card::from_string(card_name));
+        }
+
+        // execute the method under test
+        let crib = select_crib_cards(&hand, true);
+
+        // returned crib len should equal 0 given the inputs 
+        assert_eq!(crib.len(), 0);
+    }
+
+    #[test]
+    fn test_get_crib_cards_match_expected_length() {
+
+        // prepare test parameters
+        let test_hand = "FiveOfHearts,FiveOfClubs,SixOfHearts,SixOfClubs";
+        let held_cards = "AceOfSpades,FourOfDiamonds,SixOfClubs,JackOfDiamonds";
+        let mut hand: Vec<Card> = Vec::new();
+        let mut held: Vec<Card> = Vec::new();
+
+        for card_name in test_hand.split(',') {
+            hand.push(Card::from_string(card_name));
+        }
+
+        for held_name in held_cards.split(',') {
+            held.push(Card::from_string(held_name));
+        }
+
+        // execute the method under test
+        let crib = get_crib_cards(&hand, &held);
+
+        // returned crib len should equal 3 given the inputs 
+        assert_eq!(crib.len(), 3);
+    }
+
+    #[test]
+    fn test_get_crib_cards_all_match_length_zero() {
+
+        // prepare test parameters
+        let test_hand = "FiveOfHearts,FiveOfClubs,SixOfHearts,SixOfClubs";
+        let held_cards = "FiveOfHearts,FiveOfClubs,SixOfHearts,SixOfClubs";
+        let mut hand: Vec<Card> = Vec::new();
+        let mut held: Vec<Card> = Vec::new();
+
+        for card_name in test_hand.split(',') {
+            hand.push(Card::from_string(card_name));
+        }
+
+        for held_name in held_cards.split(',') {
+            held.push(Card::from_string(held_name));
+        }
+
+        // execute the method under test
+        let crib = get_crib_cards(&hand, &held);
+
+        // returned crib len should equal 0 given the inputs 
+        assert_eq!(crib.len(), 0);
+    }
+
+    #[test]
+    fn test_get_crib_cards_empty_input_length_zero() {
+
+        // prepare test parameters
+        let hand: Vec<Card> = Vec::new();
+        let held: Vec<Card> = Vec::new();
+
+        // execute the method under test
+        let crib = get_crib_cards(&hand, &held);
+
+        // returned crib len should equal 0 given the inputs 
+        assert_eq!(crib.len(), 0);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,9 +65,9 @@ fn run_test(test: &CribbageTest) -> bool {
     let crib_hand = parse_toml_hand(&test.crib_hand);
     println!("\nTest Name: {}", test.name);
     let shared_card = Card::from_string(&test.shared_card);
-    let player_score = score_hand(&player_hand, &shared_card, false);
-    let crib_score = score_hand(&crib_hand, &shared_card, true);
-    let computer_score = score_hand(&computer_hand, &shared_card, false);
+    let player_score = score_hand(&player_hand,Some(&shared_card), false);
+    let crib_score = score_hand(&crib_hand, Some(&shared_card), true);
+    let computer_score = score_hand(&computer_hand, Some(&shared_card), false);
 
     if player_score - test.player_score == 0 {
         print!("{}", "PASSED:\t".green());
@@ -217,6 +217,6 @@ fn old_main() {
     }
     println!("\n");
 
-    let player_score = score_hand(&player_hand[0..4], &shared_card, false);
+    let player_score = score_hand(&player_hand[0..4], Some(&shared_card), false);
     println!("PlayerScore is: {}", player_score);
 }


### PR DESCRIPTION
Initial implementation of select-cards.rs. Added README.md to start repo documentation effort as we go.

TODO:
- Implement fn select-counted-card

Tests...
select_cards.rs contains unit tests for get_crib_cards and integration tests for select_crib_cards. I believe to be best practice Rust, the integration tests should be moved to the tests folder in a select_cards_test.rs. However, I think the crates needs to be restructured to support tests executing in another directory.