### PR TITLE
Dev experience improvements

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,11 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/rust/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.202.1/containers/codespaces-linux/.devcontainer/base.Dockerfile
 
-FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+FROM mcr.microsoft.com/vscode/devcontainers/universal:1-focal
 
-# [Optional] Uncomment this section to install additional packages.
+# ** [Optional] Uncomment this section to install additional packages. **
+# USER root
+#
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
+#
+# USER codespace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,17 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/rust
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.202.1/containers/codespaces-linux
 {
-	"name": "Rust",
+	"name": "GitHub Codespaces (Default)",
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
+	"mounts": ["source=codespaces-linux-var-lib-docker,target=/var/lib/docker,type=volume"],
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",
 		"--security-opt",
-		"seccomp=unconfined"
+		"seccomp=unconfined",
+		"--privileged",
+		"--init"
 	],
 
 	// Set *default* container specific settings.json values on container create.
@@ -20,16 +23,18 @@
 		},
 		"rust-analyzer.checkOnSave.command": "clippy"
 	},
-
+	"overrideCommand": false,
+	
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
+		"GitHub.vscode-pull-request-github",
 		"vadimcn.vscode-lldb",
 		"mutantdino.resourcemonitor",
 		"matklad.rust-analyzer",
 		"tamasfe.even-better-toml",
 		"serayuzgur.crates"
 	],
-
+	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
@@ -37,5 +42,5 @@
 	// "postCreateCommand": "rustc --version",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "codespace"
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -123,7 +123,7 @@ async fn main() -> std::io::Result<()> {
                     ),
             )
     })
-    .bind(format!("localhost:{}", port))?
+    .bind(format!("0.0.0.0:{}", port))?
     .run()
     .await
 }

--- a/app.yaml
+++ b/app.yaml
@@ -6,5 +6,4 @@ values:
     cpu: 0.5 
     memory: 64M
     replicas: 2
-    env:
-        CRIBBAGE_PORT: 80
+    port: 8080


### PR DESCRIPTION
* Uses the GitHub Codespaces default image to enable Docker usage
* Updates `main.rs` to listen on all IPs. This is necessary, otherwise only traffic from within the container can access the API via `localhost`
* Updates `app.yaml` with the flat property bag expected by the current `external-service` template
* Updates the `Dockerfile` with BuildKit optimizations for development
  * `RUN --mount=type=cache` caches the download step so that subsequent builds don't have to redownload crates that have already been pulled ([docs](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypecache))
  * Splitting the build of dependencies vs `src` also increases speed on subsequent builds

Old build times

```
#No cached downloads/dependencies
time docker build --no-cache .

real    5m43.506s
user    0m1.239s
sys     0m0.872s

# Changed a file in src
time docker build .

real    5m44.731s
user    0m1.199s
sys     0m0.938s
```

New build times

```
#No cached downloads/dependencies
time docker build --no-cache .

real    5m51.538s
user    0m1.209s
sys     0m0.933s

# Changed a file in src
time docker build .

real    0m36.053s
user    0m0.148s
sys     0m0.145s
```