### PR TITLE
fixed a bug in cut cards.  hostname from request

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -15,44 +15,33 @@ use std::env;
 /// see the serviceProxy.js file where HOST_NAME is defined
 ///
 static PORT: OnceCell<String> = OnceCell::new();
-pub static HOST_NAME: OnceCell<String> = OnceCell::new();
 
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! safe_set_port {
-                () => {{
-                    let port: String;
-                    match PORT.get() {
-                        Some(val) => {port = val.to_string();}
-                        None => {
-
-                            match env::var("CRIBBAGE_PORT") {
-                                Ok(val) => port = val.to_string(),
-                                Err(_e) => port = "8080".to_string(),
-                            }
-                            println!("setting port to: {}", port);
-                            match PORT.set(port.clone()) {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    println!("error setting port: {:?}", e.to_string());
-                                }
-                            }
-                            let host: String = format!("localhost:{}/api", port); // TODO:  this should be picked out of the
-                            match HOST_NAME.set(host.clone()) {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    println!("error setting host: {:?}", e);
-                                }
-                            }
-
-                            println!("setting host to {}", host.clone());
-                        }
-
-
-                    };
-                    port
-                }};
+    () => {{
+        let port: String;
+        match PORT.get() {
+            Some(val) => {
+                port = val.to_string();
             }
+            None => {
+                match env::var("CRIBBAGE_PORT") {
+                    Ok(val) => port = val.to_string(),
+                    Err(_e) => port = "8080".to_string(),
+                }
+                println!("setting port to: {}", port);
+                match PORT.set(port.clone()) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        println!("error setting port: {:?}", e.to_string());
+                    }
+                }
+            }
+        };
+        port
+    }};
+}
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {


### PR DESCRIPTION
there is a bug in cut cards - before this fix it makes sure that the two cards aren't the same and it needs to make sure that the two cards do not have the same rank.  fixed here.

next, the hostname was set by config and the repeat URL is wrong if it is set when run in a service and the dev is running locally...or vice versa.  now it picks the hostname out of the HttpRequest so it should be valid in either environments.

fixed a comment on the way.